### PR TITLE
Fixed example syntax.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If it can be structured as one of the metric types below, it can consumed by Sta
 Metric Types & Formats
 ======================
 
-The format of exported metrics is UTF-8 text, with metrics separated by newlines.  Metrics are generally of the form <metric name>:<value>|<type>, with exceptions noted in the metric type definitions below.
+The format of exported metrics is UTF-8 text, with metrics separated by newlines.  Metrics are generally of the form `<metric name>:<value>|<type>`, with exceptions noted in the metric type definitions below.
 
 Gauges
 ------


### PR DESCRIPTION
Angle brackets need to be singly escaped or inside a code block. In this case, a code block makes more sense.
